### PR TITLE
update link in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Install using setuptools, e.g. (within a virtualenv)::
 
 Or if you prefer to get the latest from Github::
 
-    $ git clone git://github.com/jessedhillon/mdx_sections.git
+    $ git clone https://github.com/jessedhillon/mdx_sections.git
 
 Usage
 =====


### PR DESCRIPTION
as git:// no longer works

https://github.blog/2021-09-01-improving-git-protocol-security-github/